### PR TITLE
feat(auth-auth): implement refresh token middleware for route /auth/refresh-token.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -277,6 +277,7 @@ dependencies = [
  "async-trait",
  "chrono",
  "database",
+ "futures",
  "mockall",
  "security",
  "serde",
@@ -615,6 +616,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c2141d6d6c8512188a7891b4b01590a45f6dac67afb4f255c4124dbb86d4eaa"
 
 [[package]]
+name = "futures"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65bc07b1a8bc7c85c5f2e110c476c7389b4554ba72af57d8445ea63a576b0876"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
 name = "futures-channel"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -629,6 +645,23 @@ name = "futures-core"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
+
+[[package]]
+name = "futures-executor"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e28d1d997f585e54aebc3f97d39e72338912123a67330d723fdbb564d646c9f"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-io"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
 
 [[package]]
 name = "futures-macro"
@@ -659,10 +692,13 @@ version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
 dependencies = [
+ "futures-channel",
  "futures-core",
+ "futures-io",
  "futures-macro",
  "futures-sink",
  "futures-task",
+ "memchr",
  "pin-project-lite",
  "pin-utils",
  "slab",

--- a/apps/auth/Cargo.toml
+++ b/apps/auth/Cargo.toml
@@ -14,5 +14,6 @@ chrono = "0.4.38"
 actix-web = "4"
 tokio-postgres = "0.7"
 serde = { version = "1.0", features = ["derive"] }
+futures = "0.3"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/apps/auth/src/controllers/auth_controller.rs
+++ b/apps/auth/src/controllers/auth_controller.rs
@@ -31,7 +31,7 @@ pub fn auth_controller(config: &mut web::ServiceConfig) {
             .service(
                 web::scope("/refresh-token")
                     .wrap(refresh_middeware)
-                    .route("", web::post().to(refresh_token_handler)),
+                    .route("", web::get().to(refresh_token_handler)),
             ),
     );
 }

--- a/apps/auth/src/controllers/auth_controller.rs
+++ b/apps/auth/src/controllers/auth_controller.rs
@@ -1,9 +1,13 @@
-use actix_web::{web, HttpResponse};
+use actix_web::{web, HttpMessage, HttpRequest, HttpResponse};
 use database::pgx::Postgresql;
 use security::{env::EnvImpl, hasher::Bcrypt, jwt::JwtImpl};
 use serde::{Deserialize, Serialize};
 
-use crate::services::auth_service::{AuthService, AuthServiceImpl};
+use crate::{
+    middlewares,
+    services::auth_service::{AuthService, AuthServiceImpl},
+    utils,
+};
 
 #[derive(Serialize, Deserialize, Debug)]
 struct ResponseOk<T> {
@@ -17,11 +21,18 @@ struct ResponseError {
 }
 
 pub fn auth_controller(config: &mut web::ServiceConfig) {
+    let refresh_middeware = middlewares::refresh_middleware::Middleware {
+        roles: vec![utils::constants::REFRESH_TOKEN.to_string()],
+    };
     config.service(
         web::scope("/auth")
             .route("/signup", web::post().to(sign_up_handler))
             .route("/signin", web::post().to(sign_in_handler))
-            .route("/refresh-token", web::post().to(refresh_token_handler)),
+            .service(
+                web::scope("/refresh-token")
+                    .wrap(refresh_middeware)
+                    .route("", web::post().to(refresh_token_handler)),
+            ),
     );
 }
 
@@ -64,21 +75,26 @@ async fn sign_in_handler(
     }
 }
 
-// TODO: add middleware to check if user is have header Authorization-refresh
 async fn refresh_token_handler(
-    data: web::Json<crate::services::auth_service::GainNewTokenData>,
     ctrl: web::Data<AuthServiceImpl<Postgresql, Bcrypt, JwtImpl<EnvImpl>>>,
+    req: HttpRequest,
 ) -> HttpResponse {
-    match ctrl.gain_new_token(&data.old_token).await {
-        Ok(Some(token)) => HttpResponse::Ok().json(ResponseOk {
-            data: Some(token),
-            message: "Successfully refreshed token".to_string(),
-        }),
-        Ok(None) => HttpResponse::BadRequest().json(ResponseError {
-            message: "Failed to refresh token".to_string(),
-        }),
-        Err(err) => HttpResponse::InternalServerError().json(ResponseError {
-            message: format!("Error: {}", err),
-        }),
+    if let Some(token) = req.extensions().get::<String>() {
+        match ctrl.gain_new_token(token).await {
+            Ok(Some(new_token)) => HttpResponse::Ok().json(ResponseOk {
+                data: Some(new_token),
+                message: "Successfully refreshed token".to_string(),
+            }),
+            Ok(None) => HttpResponse::BadRequest().json(ResponseError {
+                message: "Failed to refresh token".to_string(),
+            }),
+            Err(err) => HttpResponse::InternalServerError().json(ResponseError {
+                message: format!("Error: {}", err),
+            }),
+        }
+    } else {
+        HttpResponse::BadRequest().json(ResponseError {
+            message: "Token not found in request".to_string(),
+        })
     }
 }

--- a/apps/auth/src/main.rs
+++ b/apps/auth/src/main.rs
@@ -4,8 +4,10 @@ use database::pgx::Postgresql;
 use security::{env::EnvImpl, hasher::Bcrypt, jwt::JwtImpl};
 use services::auth_service::AuthServiceImpl;
 
-pub mod controllers;
-pub mod services;
+mod controllers;
+mod middlewares;
+mod services;
+mod utils;
 
 #[actix_web::main]
 async fn main() -> std::io::Result<()> {

--- a/apps/auth/src/middlewares/mod.rs
+++ b/apps/auth/src/middlewares/mod.rs
@@ -1,0 +1,1 @@
+pub mod refresh_middleware;

--- a/apps/auth/src/middlewares/refresh_middleware.rs
+++ b/apps/auth/src/middlewares/refresh_middleware.rs
@@ -1,0 +1,140 @@
+use std::future::{ready, Ready};
+
+use actix_web::{
+    dev::{forward_ready, Service, ServiceRequest, ServiceResponse, Transform},
+    Error, HttpMessage,
+};
+use futures::future::LocalBoxFuture;
+use security::{
+    env::EnvImpl,
+    jwt::{Jwt, JwtImpl},
+};
+
+use crate::utils;
+
+pub struct Middleware {
+    pub roles: Vec<String>,
+}
+
+impl<S, B> Transform<S, ServiceRequest> for Middleware
+where
+    S: Service<ServiceRequest, Response = ServiceResponse<B>, Error = Error>,
+    S::Future: 'static,
+    B: 'static,
+{
+    type Response = ServiceResponse<B>;
+    type Error = Error;
+    type InitError = ();
+    type Transform = RefreshTokenMiddleware<S>;
+    type Future = Ready<Result<Self::Transform, Self::InitError>>;
+
+    fn new_transform(&self, service: S) -> Self::Future {
+        ready(Ok(RefreshTokenMiddleware {
+            service,
+            roles: self.roles.clone(),
+            jwt: JwtImpl::new(EnvImpl::default()),
+        }))
+    }
+}
+
+pub struct RefreshTokenMiddleware<S> {
+    service: S,
+    roles: Vec<String>,
+    jwt: JwtImpl<EnvImpl>,
+}
+
+impl<S, B> Service<ServiceRequest> for RefreshTokenMiddleware<S>
+where
+    S: Service<ServiceRequest, Response = ServiceResponse<B>, Error = Error>,
+    S::Future: 'static,
+    B: 'static,
+{
+    type Response = ServiceResponse<B>;
+    type Error = Error;
+    type Future = LocalBoxFuture<'static, Result<Self::Response, Self::Error>>;
+
+    forward_ready!(service);
+
+    fn call(&self, req: ServiceRequest) -> Self::Future {
+        println!("RefreshTokenMiddleware: executing middleware");
+
+        // Check if roles exist in middleware
+        if !self.roles.is_empty() {
+            println!("RefreshTokenMiddleware: checking roles");
+
+            // Try to get the Authorization-refresh header
+            let token_header = req.headers().get("Authorization-refresh");
+
+            if token_header.is_none() {
+                println!("RefreshTokenMiddleware: missing Authorization-refresh header");
+                return Box::pin(ready(Err(actix_web::error::ErrorUnauthorized(
+                    "Unauthorized: Missing Authorization-refresh header",
+                ))));
+            }
+
+            let token_str = token_header.unwrap().to_str();
+            // split Bearer from token
+            let token_str = token_str.map(|s| s.split("Bearer ").collect::<Vec<_>>()[1]);
+            if token_str.is_err() {
+                println!("RefreshTokenMiddleware: invalid token format");
+                return Box::pin(ready(Err(actix_web::error::ErrorUnauthorized(
+                    "Unauthorized: Invalid token format",
+                ))));
+            }
+
+            let token = token_str.unwrap();
+
+            // Validate JWT token
+            let claims = self.jwt.extract(&token);
+            if claims.is_none() {
+                println!("RefreshTokenMiddleware: failed to extract token claims");
+                return Box::pin(ready(Err(actix_web::error::ErrorUnauthorized(
+                    "Unauthorized: Invalid or expired token",
+                ))));
+            }
+
+            let claims = claims.unwrap();
+
+            // Validate role
+            if !roles_is_valid(&self.roles, &claims.additional_claims.kind) {
+                println!("RefreshTokenMiddleware: unauthorized role");
+                return Box::pin(ready(Err(actix_web::error::ErrorUnauthorized(
+                    "Unauthorized: Invalid role",
+                ))));
+            }
+
+            // Check if the token is of the type REFRESH_TOKEN
+            if claims.additional_claims.kind != utils::constants::REFRESH_TOKEN {
+                println!("RefreshTokenMiddleware: invalid token type");
+                return Box::pin(ready(Err(actix_web::error::ErrorUnauthorized(
+                    "Unauthorized: Token is not a refresh token",
+                ))));
+            }
+
+            println!("RefreshTokenMiddleware: token and role validated");
+
+            // Attach token to request extensions for future use
+            req.extensions_mut().insert(token.to_string());
+        }
+
+        // Continue with the request
+        let fut = self.service.call(req);
+
+        Box::pin(async move {
+            let res = fut.await?;
+
+            println!("RefreshTokenMiddleware: after request processing");
+
+            Ok(res)
+        })
+    }
+}
+
+fn roles_is_valid(roles: &Vec<String>, role: &str) -> bool {
+    for r in roles {
+        if r == role {
+            return true;
+        }
+    }
+    return false;
+}

--- a/apps/auth/src/services/auth_service.rs
+++ b/apps/auth/src/services/auth_service.rs
@@ -7,6 +7,8 @@ use security::{
 };
 use serde::{Deserialize, Serialize};
 
+use crate::utils::constants::{AUTH_TOKEN, REFRESH_TOKEN};
+
 #[derive(Serialize, Deserialize, Debug)]
 pub struct TokenData {
     pub token: String,
@@ -72,21 +74,21 @@ impl<T: Database + Send + Sync, B: Hasher + Send + Sync, E: Jwt + Send + Sync> A
                     let token = self.jwt.sign(&Claims {
                         sub: username.clone(),
                         iat: Utc::now().timestamp() as usize,
-                        aud: username.clone(),
                         exp: (Utc::now() + Duration::hours(1)).timestamp() as usize,
                         nbf: Utc::now().timestamp() as usize,
                         additional_claims: AdditionalClaims {
                             user_id: user_id.clone(),
+                            kind: AUTH_TOKEN.to_string(),
                         },
                     });
                     let refresh_token = self.jwt.sign(&Claims {
                         sub: username.clone(),
                         iat: Utc::now().timestamp() as usize,
-                        aud: username.clone(),
                         exp: (Utc::now() + Duration::weeks(4)).timestamp() as usize,
                         nbf: Utc::now().timestamp() as usize,
                         additional_claims: AdditionalClaims {
                             user_id: user_id.clone(),
+                            kind: REFRESH_TOKEN.to_string(),
                         },
                     });
 
@@ -138,11 +140,11 @@ impl<T: Database + Send + Sync, B: Hasher + Send + Sync, E: Jwt + Send + Sync> A
             let claims = Claims {
                 sub: old_claims.sub.clone(),
                 iat: Utc::now().timestamp() as usize,
-                aud: old_claims.aud.clone(),
                 exp: expired,
                 nbf: Utc::now().timestamp() as usize,
                 additional_claims: AdditionalClaims {
                     user_id: old_claims.additional_claims.user_id.clone(),
+                    kind: old_claims.additional_claims.kind.clone(),
                 },
             };
 

--- a/apps/auth/src/utils/constants.rs
+++ b/apps/auth/src/utils/constants.rs
@@ -1,0 +1,2 @@
+pub const REFRESH_TOKEN: &str = "refresh_token";
+pub const AUTH_TOKEN: &str = "auth_token";

--- a/apps/auth/src/utils/mod.rs
+++ b/apps/auth/src/utils/mod.rs
@@ -1,0 +1,1 @@
+pub mod constants;


### PR DESCRIPTION
Implement a refresh token middleware and make a custom header ```Authorization-refresh``` for route ```/auth/refresh-token```. In previus version when performing a refresh-token we need to add json body in request now we use ```Authorization-refresh``` header to add Bearer token. Also change the post method to get method in ```/auth/refresh-token```.